### PR TITLE
Making the travis build WAY faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ cache: pip
 addons:
   apt:
     packages:
-    - python-pip
     - libeigen3-dev
 
 before_install:
@@ -32,8 +31,8 @@ before_install:
 install:
   - conda create --yes -n test python=$TRAVIS_PYTHON_VERSION
   - source activate test
-  - conda install --yes numpy scipy nose pip
-  - pip install coveralls
+  - conda install --yes numpy scipy matplotlib nose pip astropy six statsmodels 
+  - pip install coveralls astroML astroML_addons george==0.2.1
   - python setup.py install
 
 script: 


### PR DESCRIPTION
You should install matplotlib, astropy, etc. as part of the `setup.py install` because this will build them from source. That's why your builds take so long. This installs all of the deps using pip and conda first. I haven't tested this but it _should_ work.