### PR TITLE
C12 Raw cadence data functionality

### DIFF
--- a/everest/__init__.py
+++ b/everest/__init__.py
@@ -24,15 +24,17 @@ if not __EVEREST_SETUP__:
   from . import fits
   from . import dvs
   from . import gp
+  from . import search
   from . import missions
   from . import basecamp
   from . import detrender
   from . import inject
   from . import user
   
+  
   # Import the good stuff
   from .detrender import *
   from .inject import *
   from .missions import *
-  from .transit import Transit, Planet, TransitShape
+  from .transit import Transit, TransitModel, TransitShape
   from .user import Everest, DVS

--- a/everest/__init__.py
+++ b/everest/__init__.py
@@ -34,5 +34,5 @@ if not __EVEREST_SETUP__:
   from .detrender import *
   from .inject import *
   from .missions import *
-  from .transit import Transit
+  from .transit import Transit, Planet
   from .user import Everest, DVS

--- a/everest/__init__.py
+++ b/everest/__init__.py
@@ -34,5 +34,5 @@ if not __EVEREST_SETUP__:
   from .detrender import *
   from .inject import *
   from .missions import *
-  from .transit import Transit, Planet
+  from .transit import Transit, Planet, TransitShape
   from .user import Everest, DVS

--- a/everest/basecamp.py
+++ b/everest/basecamp.py
@@ -450,7 +450,7 @@ class Basecamp(object):
       self.transit_depth = np.array([med * tm.depth + w_trn[i] for i, tm in enumerate(self.transit_model)]) / med
 
       # Remove the transit prediction from the model
-      self.model -= med * np.dot(np.hstack([tm(self.time).reshape(-1,1) for tm in self.transit_model]), self.transit_depth)
+      self.model -= np.dot(np.hstack([tm(self.time).reshape(-1,1) for tm in self.transit_model]), w_trn)
       
     else:
       

--- a/everest/detrender.py
+++ b/everest/detrender.py
@@ -20,7 +20,6 @@ from .math import Chunks, Scatter, SavGol, Interpolate
 from .fits import MakeFITS
 from .gp import GetCovariance, GetKernelParams
 from .dvs import DVS, CBV
-from .transit import TransitModel
 import os, sys
 import numpy as np
 import george
@@ -210,12 +209,7 @@ class Detrender(Basecamp):
     self.pld_order = pld_order
     
     # Get the transit model
-    self.transit_model = kwargs.get('transit_model', None)
-    if self.transit_model is not None:
-      self.transit_model = np.atleast_1d(self.transit_model)
-      for tm in self.transit_model:
-        assert type(tm) is TransitModel, "Kwarg `transit_model` must be an instance or a list of instances of `everest.TransitModel`."
-    self.transit_depths = None
+    self._transit_model = kwargs.get('transit_model', None)
     
     # Initialize model params 
     self.lam_idx = -1

--- a/everest/detrender.py
+++ b/everest/detrender.py
@@ -522,6 +522,7 @@ class Detrender(Basecamp):
         # Plot cross-val
         for n in range(len(masks)):
           ax[b].plot(np.log10(lambda_arr), validation[:,n], 'r-', alpha = 0.3)
+          
         ax[b].plot(np.log10(lambda_arr), med_training, 'b-', lw = 1., alpha = 1)
         ax[b].plot(np.log10(lambda_arr), med_validation, 'r-', lw = 1., alpha = 1)            
         ax[b].axvline(np.log10(self.lam[b][self.lam_idx]), color = 'k', ls = '--', lw = 0.75, alpha = 0.75)
@@ -639,7 +640,7 @@ class Detrender(Basecamp):
     '''
 
     # Plot
-    if self.cadence == 'lc':
+    if (self.cadence == 'lc') or (len(self.time) < 4000):
       ax.plot(self.apply_mask(self.time), self.apply_mask(self.flux), ls = 'none', marker = '.', color = color, markersize = 2, alpha = 0.5)
       ax.plot(self.time[self.transitmask], self.flux[self.transitmask], ls = 'none', marker = '.', color = color, markersize = 2, alpha = 0.5)
     else:
@@ -726,7 +727,7 @@ class Detrender(Basecamp):
     # Plot the light curve
     bnmask = np.array(list(set(np.concatenate([self.badmask, self.nanmask]))), dtype = int)
     M = lambda x: np.delete(x, bnmask)
-    if self.cadence == 'lc':
+    if (self.cadence == 'lc') or (len(self.time) < 4000):
       ax.plot(M(self.time), M(self.flux), ls = 'none', marker = '.', color = 'k', markersize = 2, alpha = 0.3)
     else:
       ax.plot(M(self.time), M(self.flux), ls = 'none', marker = '.', color = 'k', markersize = 2, alpha = 0.03, zorder = -1)

--- a/everest/detrender.py
+++ b/everest/detrender.py
@@ -979,6 +979,7 @@ class Detrender(Basecamp):
     d.pop('_mission', None)
     d.pop('debug', None)
     d.pop('transit_model', None)
+    d.pop('_transit_model', None)
     np.savez(os.path.join(self.dir, self.name + '.npz'), **d)
     
     # Save the DVS
@@ -1043,7 +1044,7 @@ class Detrender(Basecamp):
       if self.kernel == 'Basic':
         self.kernel_params = [white, amp, tau]
       elif self.kernel == 'QuasiPeriodic':
-        self.kernel_params = [white, amp, tau, 1., 20.]
+        self.kernel_params = [white, amp, 1., 20.]
         
   def mask_planets(self):
     '''

--- a/everest/fits.py
+++ b/everest/fits.py
@@ -96,13 +96,16 @@ def LightcurveHDU(model):
   cards.append(('GITER', model.giter, 'Number of GP optimiziation iterations'))
   cards.append(('GMAXF', model.giter, 'Max number of GP function evaluations'))
   cards.append(('GPFACTOR', model.gp_factor, 'GP amplitude initialization factor'))
-  cards.append(('GPWHITE', model.kernel_params[0], 'GP white noise amplitude (e-/s)'))
-  cards.append(('GPRED', model.kernel_params[1], 'GP red noise amplitude (e-/s)'))
-  cards.append(('GPTAU', model.kernel_params[2], 'GP red noise timescale (days)'))
   cards.append(('KERNEL', model.kernel, 'GP kernel name'))
-  if model.kernel == 'QuasiPeriodic':
-    cards.append(('GPGAMMA', model.kernel_params[3], 'GP scale factor'))
-    cards.append(('GPPER', model.kernel_params[4], 'GP period (days)'))
+  if model.kernel == 'Basic':
+    cards.append(('GPWHITE', model.kernel_params[0], 'GP white noise amplitude (e-/s)'))
+    cards.append(('GPRED', model.kernel_params[1], 'GP red noise amplitude (e-/s)'))
+    cards.append(('GPTAU', model.kernel_params[2], 'GP red noise timescale (days)'))
+  elif model.kernel == 'QuasiPeriodic':
+    cards.append(('GPWHITE', model.kernel_params[0], 'GP white noise amplitude (e-/s)'))
+    cards.append(('GPRED', model.kernel_params[1], 'GP red noise amplitude (e-/s)'))
+    cards.append(('GPGAMMA', model.kernel_params[2], 'GP scale factor'))
+    cards.append(('GPPER', model.kernel_params[3], 'GP period (days)'))
   for c in range(len(model.breakpoints)):
     for o in range(model.pld_order):
       cards.append(('LAMB%02d%02d' % (c + 1, o + 1), model.lam[c][o], 'Cross-validation parameter'))

--- a/everest/fits.py
+++ b/everest/fits.py
@@ -99,6 +99,10 @@ def LightcurveHDU(model):
   cards.append(('GPWHITE', model.kernel_params[0], 'GP white noise amplitude (e-/s)'))
   cards.append(('GPRED', model.kernel_params[1], 'GP red noise amplitude (e-/s)'))
   cards.append(('GPTAU', model.kernel_params[2], 'GP red noise timescale (days)'))
+  cards.append(('KERNEL', model.kernel, 'GP kernel name'))
+  if model.kernel == 'QuasiPeriodic':
+    cards.append(('GPGAMMA', model.kernel_params[3], 'GP scale factor'))
+    cards.append(('GPPER', model.kernel_params[4], 'GP period (days)'))
   for c in range(len(model.breakpoints)):
     for o in range(model.pld_order):
       cards.append(('LAMB%02d%02d' % (c + 1, o + 1), model.lam[c][o], 'Cross-validation parameter'))

--- a/everest/gp.py
+++ b/everest/gp.py
@@ -27,7 +27,7 @@ def GP(kernel, kernel_params, white = False):
   if kernel == 'Basic':
     white, amp, tau = kernel_params
     if white:
-      return george.GP(white ** 2 + amp ** 2 * Matern32Kernel(tau ** 2))
+      return george.GP(WhiteKernel(white ** 2) + amp ** 2 * Matern32Kernel(tau ** 2))
     else:
       return george.GP(amp ** 2 * Matern32Kernel(tau ** 2))
   elif kernel == 'QuasiPeriodic':

--- a/everest/gp.py
+++ b/everest/gp.py
@@ -31,11 +31,11 @@ def GP(kernel, kernel_params, white = False):
     else:
       return george.GP(amp ** 2 * Matern32Kernel(tau ** 2))
   elif kernel == 'QuasiPeriodic':
-    white, amp, tau, gamma, period = kernel_params
+    white, amp, gamma, period = kernel_params
     if white:
-      return george.GP(white ** 2 + amp ** 2 * Matern32Kernel(tau ** 2) * ExpSine2Kernel(gamma, period))
+      return george.GP(white ** 2 + amp ** 2 * ExpSine2Kernel(gamma, period))
     else:
-      return george.GP(amp ** 2 * Matern32Kernel(tau ** 2) * ExpSine2Kernel(gamma, period))
+      return george.GP(amp ** 2 * ExpSine2Kernel(gamma, period))
   else:
     raise ValueError('Invalid value for `kernel`.')
     
@@ -109,7 +109,7 @@ def GetKernelParams(time, flux, errors, kernel = 'Basic', mask = [], giter = 3, 
       guess = [white, amp, tau, 1., 20.]
     bounds = [[0.1 * white, 10. * white], 
               [1., 10000. * amp],
-              [0.01, 10.],
+              [1e-5, 1e2],
               [0.02, 100.]]
   else:
     raise ValueError('Invalid value for `kernel`.')
@@ -138,12 +138,15 @@ def GetKernelParams(time, flux, errors, kernel = 'Basic', mask = [], giter = 3, 
     log.info('   ' + x[2]['task'].decode('utf-8'))
     log.info('   ' + 'Function calls: %d' % x[2]['funcalls'])
     log.info('   ' + 'Log-likelihood: %.3e' % -x[1])
-    log.info('   ' + 'White noise   : %.3e (%.1f x error bars)' % (x[0][0], x[0][0] / np.nanmedian(errors)))
-    log.info('   ' + 'Red amplitude : %.3e (%.1f x stand dev)' % (x[0][1], x[0][1] / np.nanstd(flux)))
-    log.info('   ' + 'Red timescale : %.2f days' % x[0][2])
-    if kernel == 'QuasiPeriodic':
-      log.info('   ' + 'Gamma       : %.2f' % x[0][3])
-      log.info('   ' + 'Period      : %.2f days' % x[0][4])
+    if kernel == 'Basic':
+      log.info('   ' + 'White noise   : %.3e (%.1f x error bars)' % (x[0][0], x[0][0] / np.nanmedian(errors)))
+      log.info('   ' + 'Red amplitude : %.3e (%.1f x stand dev)' % (x[0][1], x[0][1] / np.nanstd(flux)))
+      log.info('   ' + 'Red timescale : %.2f days' % x[0][2])
+    elif kernel == 'QuasiPeriodic':
+      log.info('   ' + 'White noise   : %.3e (%.1f x error bars)' % (x[0][0], x[0][0] / np.nanmedian(errors)))
+      log.info('   ' + 'Red amplitude : %.3e (%.1f x stand dev)' % (x[0][1], x[0][1] / np.nanstd(flux)))
+      log.info('   ' + 'Gamma         : %.3e' % x[0][2])
+      log.info('   ' + 'Period        : %.2f days' % x[0][3])
     if -x[1] > llbest:
       llbest = -x[1]
       xbest = np.array(x[0])

--- a/everest/gp.py
+++ b/everest/gp.py
@@ -25,17 +25,17 @@ def GP(kernel, kernel_params, white = False):
   '''
   
   if kernel == 'Basic':
-    white, amp, tau = kernel_params
+    w, a, t = kernel_params
     if white:
-      return george.GP(WhiteKernel(white ** 2) + amp ** 2 * Matern32Kernel(tau ** 2))
+      return george.GP(WhiteKernel(w ** 2) + a ** 2 * Matern32Kernel(t ** 2))
     else:
-      return george.GP(amp ** 2 * Matern32Kernel(tau ** 2))
+      return george.GP(a ** 2 * Matern32Kernel(t ** 2))
   elif kernel == 'QuasiPeriodic':
-    white, amp, gamma, period = kernel_params
+    w, a, g, p = kernel_params
     if white:
-      return george.GP(white ** 2 + amp ** 2 * ExpSine2Kernel(gamma, period))
+      return george.GP(WhiteKernel(w ** 2) + a ** 2 * ExpSine2Kernel(g, p))
     else:
-      return george.GP(amp ** 2 * ExpSine2Kernel(gamma, period))
+      return george.GP(a ** 2 * ExpSine2Kernel(g, p))
   else:
     raise ValueError('Invalid value for `kernel`.')
     

--- a/everest/search.py
+++ b/everest/search.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+'''
+search.py
+---------
+
+Given an `everest` instance, performs a transit search
+and returns an array of delta chi-squared values. This
+approach is similar to that in Foreman-Mackey et al. (2015).
+
+'''
+
+from __future__ import division, print_function, absolute_import, unicode_literals
+import numpy as np
+from .math import SavGol
+from .gp import GetCovariance
+from .transit import TransitShape
+from scipy.linalg import cho_solve, cho_factor
+from scipy.linalg import block_diag
+try:
+  from tqdm import tqdm
+  prange = lambda x: tqdm(range(x))
+except ImportError:
+  prange = lambda x: range(x)
+import logging
+log = logging.getLogger(__name__)
+
+def Search(star, pos_tol = 2.5, neg_tol = 50., **ps_kwargs):
+  '''
+  NOTE: `pos_tol` is the positive (i.e., above the median) outlier tolerance in standard deviations.
+  NOTE: `neg_tol` is the negative (i.e., below the median) outlier tolerance in standard deviations.
+  
+  '''
+  
+  # Smooth the light curve
+  t = np.delete(star.time, np.concatenate([star.nanmask, star.badmask]))
+  f = np.delete(star.flux, np.concatenate([star.nanmask, star.badmask]))
+  f = SavGol(f)
+  med = np.nanmedian(f)
+  
+  # Kill positive outliers
+  MAD = 1.4826 * np.nanmedian(np.abs(f - med))
+  pos_inds = np.where((f > med + pos_tol * MAD))[0]
+  pos_inds = np.array([np.argmax(star.time == t[i]) for i in pos_inds])
+  
+  # Kill negative outliers
+  MAD = 1.4826 * np.nanmedian(np.abs(f - med))
+  neg_inds = np.where((f < med - neg_tol * MAD))[0]
+  neg_inds = np.array([np.argmax(star.time == t[i]) for i in neg_inds])
+  
+  # Replace the star.outmask array
+  star.outmask = np.concatenate([neg_inds, pos_inds])
+  star.transitmask = np.array([], dtype = int)
+  
+  # Delta chi squared
+  TIME = np.array([])
+  DEPTH = np.array([])
+  VARDEPTH = np.array([])
+  DELCHISQ = np.array([])
+  for b, brkpt in enumerate(star.breakpoints):
+    
+    # Log
+    log.info('Running chunk %d/%d...' % (b + 1, len(star.breakpoints)))
+    
+    # Masks for current chunk
+    m = star.get_masked_chunk(b, pad = False)
+    
+    # This block of the masked covariance matrix
+    K = GetCovariance(star.kernel_params, star.time[m], star.fraw_err[m])
+    
+    # The masked X.L.X^T term
+    A = np.zeros((len(m), len(m)))
+    for n in range(star.pld_order):
+      XM = star.X(n,m)
+      A += star.lam[b][n] * np.dot(XM, XM.T)
+    K += A
+    CDK = cho_factor(K)
+    
+    # Baseline
+    med = np.nanmedian(star.fraw[m])
+    lnL0 = -0.5 * np.dot(star.fraw[m], cho_solve(CDK, star.fraw[m]))
+    dt = np.median(np.diff(star.time[m]))
+
+    # Create a uniform time array and get indices of missing cadences
+    tol = np.nanmedian(np.diff(star.time[m])) / 5.
+    tunif = np.arange(star.time[m][0], star.time[m][-1] + tol, dt)
+    tnogaps = np.array(tunif)
+    gaps = []
+    j = 0
+    for i, t in enumerate(tunif):
+      if np.abs(star.time[m][j] - t) < tol:
+        tnogaps[i] = star.time[m][j]
+        j += 1
+        if j == len(star.time[m]):
+          break 
+      else:
+        gaps.append(i)
+    gaps = np.array(gaps, dtype = int)
+
+    # Compute the normalized transit model for a single transit
+    transit_model = TransitShape(**ps_kwargs)
+
+    # Now roll the transit model across each cadence
+    dchisq = np.zeros(len(tnogaps))
+    d = np.zeros(len(tnogaps))
+    vard = np.zeros(len(tnogaps))
+    for i in prange(len(tnogaps)):
+      trn = transit_model(tnogaps, tnogaps[i])
+      trn = np.delete(trn, gaps)
+      trn *= med
+      vard[i] = 1. / np.dot(trn, cho_solve(CDK, trn))
+      if not np.isfinite(vard[i]):
+        vard[i] = np.nan
+        d[i] = np.nan
+        dchisq[i] = np.nan
+        continue
+      d[i] = vard[i] * np.dot(trn, cho_solve(CDK, star.fraw[m]))
+      r = star.fraw[m] - trn * d[i]
+      lnL = -0.5 * np.dot(r, cho_solve(CDK, r))
+      dchisq[i] = -2 * (lnL0 - lnL)
+      
+    TIME = np.append(TIME, tnogaps)
+    DEPTH = np.append(DEPTH, d)
+    VARDEPTH = np.append(VARDEPTH, vard)
+    DELCHISQ = np.append(DELCHISQ, dchisq)
+
+  return TIME, DEPTH, VARDEPTH, DELCHISQ

--- a/everest/search.py
+++ b/everest/search.py
@@ -66,7 +66,7 @@ def Search(star, pos_tol = 2.5, neg_tol = 50., **ps_kwargs):
     m = star.get_masked_chunk(b, pad = False)
     
     # This block of the masked covariance matrix
-    K = GetCovariance(star.kernel_params, star.time[m], star.fraw_err[m])
+    K = GetCovariance(star.kernel, star.kernel_params, star.time[m], star.fraw_err[m])
     
     # The masked X.L.X^T term
     A = np.zeros((len(m), len(m)))

--- a/everest/transit.py
+++ b/everest/transit.py
@@ -29,9 +29,19 @@ class Planet(object):
     '''
     
     '''
-
+    
+    # The transit model
     self._transit = ps.Transit(**kwargs)
-    self.depth = (1. - self._transit([kwargs.get('t0', 0.)]))[0]
+    
+    # Compute the depth
+    times = kwargs.get('times', None)
+    if times is not None:
+      t0 = times[0]
+    else:
+      t0 = kwargs.get('t0', 0.)
+    self.depth = (1. - self._transit([t0]))[0]
+    
+    # Approximate variance on the depth
     self.var_depth = (2 * sig_RpRs) ** 2
     
   def __call__(self, time):

--- a/everest/transit.py
+++ b/everest/transit.py
@@ -44,6 +44,9 @@ class TransitModel(object):
     # Approximate variance on the depth
     self.var_depth = (2 * sig_RpRs) ** 2
     
+    # Save the kwargs
+    self.params = kwargs
+    
   def __call__(self, time):
     '''
     

--- a/everest/transit.py
+++ b/everest/transit.py
@@ -25,10 +25,14 @@ class TransitModel(object):
   
   '''
   
-  def __init__(self, sig_RpRs = 0.001, **kwargs):
+  def __init__(self, name, sig_RpRs = 0.001, **kwargs):
     '''
     
     '''
+    
+    # The planet/transit model ID
+    assert type(name) is str, "Arg `name` must be a string."
+    self.name = name
     
     # The transit model
     self._transit = ps.Transit(**kwargs)

--- a/everest/transit.py
+++ b/everest/transit.py
@@ -115,10 +115,11 @@ def Transit(time, t0 = 0., dur = 0.1, per = 3.56789, depth = 0.001, **kwargs):
 
 class TransitShape(object):
   '''
+  TODO, NOTE: Duration is not defined the proper way here...
   
   '''
   
-  def __init__(self, dur = 0.1, depth = 1, window = 2.5, **kwargs):
+  def __init__(self, dur = 0.1, depth = 1, window = 0.5, **kwargs):
     '''
     
     '''
@@ -127,16 +128,15 @@ class TransitShape(object):
     kwargs.pop('times', None)
     t = np.linspace(-window / 2, window / 2, 5000)
     trn = ps.Transit(t0 = 0., **kwargs)
-    unbinned = trn(t, 'unbinned')
-    tinds = np.where(unbinned < 1)[0]
+    transit_model = trn(t)
+    tinds = np.where(transit_model < 1)[0]
     stretch = dur / (t[tinds][-1] - t[tinds][0])
     t *= stretch
-    transit_model = trn(t)
     transit_model -= 1
     transit_model *= depth / (1 - trn([0.])[0])
     self.thires = t
     self.model = transit_model
-  
+    
   def __call__(self, time, t0 = 0.):
     '''
     

--- a/everest/transit.py
+++ b/everest/transit.py
@@ -20,6 +20,28 @@ from scipy.optimize import fmin
 import logging
 log = logging.getLogger(__name__)
 
+class Planet(object):
+  '''
+  
+  '''
+  
+  def __init__(self, sig_RpRs = 0.001, **kwargs):
+    '''
+    
+    '''
+
+    self._transit = ps.Transit(**kwargs)
+    self.depth = (1. - self._transit([kwargs.get('t0', 0.)]))[0]
+    self.var_depth = (2 * sig_RpRs) ** 2
+    
+  def __call__(self, time):
+    '''
+    
+    '''
+    
+    model = (self._transit(time) - 1) / self.depth
+    return model 
+
 def Get_RpRs(d, **kwargs):
   '''
   Returns the value of the planet radius over the stellar radius for a given depth :py:obj:`d`, given

--- a/everest/transit.py
+++ b/everest/transit.py
@@ -20,7 +20,7 @@ from scipy.optimize import fmin
 import logging
 log = logging.getLogger(__name__)
 
-class Planet(object):
+class TransitModel(object):
   '''
   
   '''
@@ -93,8 +93,7 @@ def Get_rhos(dur, **kwargs):
 def Transit(time, t0 = 0., dur = 0.1, per = 3.56789, depth = 0.001, **kwargs):
   '''
   A `Mandel-Agol <http://adsabs.harvard.edu/abs/2002ApJ...580L.171M>`_ transit model, 
-  but with the depth and the duration
-  as primary input variables.
+  but with the depth and the duration as primary input variables.
   
   :param numpy.ndarray time: The time array
   :param float t0: The time of first transit in units of :py:obj:`BJD` - 2454833.
@@ -115,11 +114,10 @@ def Transit(time, t0 = 0., dur = 0.1, per = 3.56789, depth = 0.001, **kwargs):
 
 class TransitShape(object):
   '''
-  TODO, NOTE: Duration is not defined the proper way here...
   
   '''
   
-  def __init__(self, dur = 0.1, depth = 1, window = 0.5, **kwargs):
+  def __init__(self, depth = 1, window = 0.5, **kwargs):
     '''
     
     '''
@@ -129,17 +127,14 @@ class TransitShape(object):
     t = np.linspace(-window / 2, window / 2, 5000)
     trn = ps.Transit(t0 = 0., **kwargs)
     transit_model = trn(t)
-    tinds = np.where(transit_model < 1)[0]
-    stretch = dur / (t[tinds][-1] - t[tinds][0])
-    t *= stretch
     transit_model -= 1
     transit_model *= depth / (1 - trn([0.])[0])
-    self.thires = t
-    self.model = transit_model
+    self.x = t
+    self.y = transit_model
     
   def __call__(self, time, t0 = 0.):
     '''
     
     '''
-    
-    return np.interp(time, self.thires + t0, self.model)
+
+    return np.interp(time, self.x + t0, self.y)

--- a/everest/transit.py
+++ b/everest/transit.py
@@ -74,7 +74,7 @@ def Get_rhos(dur, **kwargs):
   
   '''
   
-  assert dur >= 0.05 and dur <= 0.5, "Invalid value for the duration."
+  assert dur >= 0.01 and dur <= 0.5, "Invalid value for the duration."
   
   def Dur(rhos, **kwargs):
     t0 = kwargs.get('t0', 0.)
@@ -112,3 +112,34 @@ def Transit(time, t0 = 0., dur = 0.1, per = 3.56789, depth = 0.001, **kwargs):
   RpRs = Get_RpRs(depth, t0 = t0, per = per, **kwargs)
   rhos = Get_rhos(dur, t0 = t0, per = per, **kwargs)
   return ps.Transit(t0 = t0, per = per, RpRs = RpRs, rhos = rhos, **kwargs)(time)
+
+class TransitShape(object):
+  '''
+  
+  '''
+  
+  def __init__(self, dur = 0.1, depth = 1, window = 2.5, **kwargs):
+    '''
+    
+    '''
+    
+    kwargs.pop('t0', None)
+    kwargs.pop('times', None)
+    t = np.linspace(-window / 2, window / 2, 5000)
+    trn = ps.Transit(t0 = 0., **kwargs)
+    unbinned = trn(t, 'unbinned')
+    tinds = np.where(unbinned < 1)[0]
+    stretch = dur / (t[tinds][-1] - t[tinds][0])
+    t *= stretch
+    transit_model = trn(t)
+    transit_model -= 1
+    transit_model *= depth / (1 - trn([0.])[0])
+    self.thires = t
+    self.model = transit_model
+  
+  def __call__(self, time, t0 = 0.):
+    '''
+    
+    '''
+    
+    return np.interp(time, self.thires + t0, self.model)

--- a/everest/transit.py
+++ b/everest/transit.py
@@ -40,7 +40,7 @@ class TransitModel(object):
     else:
       t0 = kwargs.get('t0', 0.)
     self.depth = (1. - self._transit([t0]))[0]
-    
+
     # Approximate variance on the depth
     self.var_depth = (2 * sig_RpRs) ** 2
     

--- a/everest/user.py
+++ b/everest/user.py
@@ -1150,7 +1150,28 @@ class Everest(Basecamp):
   
   def plot_transit_model(self, show = True):
     '''
-  
+    Try the following:
+    
+    .. code-block:: python
+    
+      import everest
+      star = everest.Everest(211916756)
+
+      # Planet parameters from Obermeier et al. (2016)
+      transit_model = everest.TransitModel(t0 = 2338.1477, per = 10.13389, 
+                                           aRs = 1/0.04, RpRs = 0.001, 
+                                           b = 0.6, sig_RpRs = 0.1)
+
+      # Compute the joint model
+      star.transit_model = transit_model
+      star.compute()
+
+      # Plot
+      star.plot_transit_model()
+      print(star.transit_depth)
+      
+    The true value of `RpRs` is 0.0786, and we recover that quite nicely.
+    
     '''
   
     if self.transit_model is None:

--- a/everest/user.py
+++ b/everest/user.py
@@ -381,7 +381,10 @@ class Everest(Basecamp):
       self.giter = f[1].header['GITER']
       self.gmaxf = f[1].header.get('GMAXF', 200)
       self.gp_factor = f[1].header['GPFACTOR']
-      self.hires = f[5].data
+      try:
+        self.hires = f[5].data
+      except:
+        self.hires = None
       self.kernel_params = np.array([f[1].header['GPWHITE'], 
                                      f[1].header['GPRED'], 
                                      f[1].header['GPTAU']])
@@ -1224,7 +1227,7 @@ class Everest(Basecamp):
       ax.plot(self.apply_mask(time), self.apply_mask(flux), ls = 'none', marker = '.', color = 'k', markersize = ms, alpha = 0.5)
       ax.plot(time[self.outmask], flux[self.outmask], ls = 'none', marker = '.', color = 'k', markersize = ms, alpha = 0.5)
       ax.plot(time[self.transitmask], flux[self.transitmask], ls = 'none', marker = '.', color = 'k', markersize = ms, alpha = 0.5)
-      hires_time = np.linspace(-3 * dur, 3 * dur, 1000)
+      hires_time = np.linspace(-5 * dur, 5 * dur, 1000)
       hires_transit_model = 1 + self.transit_depth[fold] * self.transit_model[fold](hires_time + t0)
       ax.plot(hires_time, hires_transit_model, 'r-', lw = 1, alpha = 1)
     else:
@@ -1253,7 +1256,7 @@ class Everest(Basecamp):
     # Get y lims that bound 99% of the flux
     if fold is not None:
       f = flux[np.where(np.abs(time) < 3 * dur)]
-      N = int(0.9 * len(f))
+      N = int(0.999 * len(f))
     else:
       f = np.delete(flux, bnmask)
       N = int(0.995 * len(f))

--- a/everest/user.py
+++ b/everest/user.py
@@ -470,6 +470,7 @@ class Everest(Basecamp):
     self.parent_model = None
     self.lambda_arr = None
     self.meta = None
+    self.transit_model = None
   
   def plot_aperture(self, show = True):
     '''

--- a/everest/user.py
+++ b/everest/user.py
@@ -471,6 +471,7 @@ class Everest(Basecamp):
     self.lambda_arr = None
     self.meta = None
     self.transit_model = None
+    self.transit_depths = None
   
   def plot_aperture(self, show = True):
     '''


### PR DESCRIPTION
Added functionality to allow the ingestion of raw cadence data into EVEREST. This helps with the recent [C12 release of the TRAPPIST-1 data](https://keplerscience.arc.nasa.gov/raw-data-for-k2-campaign-12-and-trappist-1-now-available.html). Made some other tweaks as well -- users can now simultaneously fit an instrumental/transit model and use EVEREST to perform transit searches.